### PR TITLE
Use aliases for path-independent imports

### DIFF
--- a/app/scripts/actions/boreholes.es6
+++ b/app/scripts/actions/boreholes.es6
@@ -1,5 +1,5 @@
 import { createActions } from 'reflux';
-import { getBoreholes } from '../api';
+import { getBoreholes } from 'scripts/api';
 
 const boreholesActions = createActions({
   load: {},

--- a/app/scripts/actions/dams.es6
+++ b/app/scripts/actions/dams.es6
@@ -1,5 +1,5 @@
 import { createActions } from 'reflux';
-import { getDams } from '../api';
+import { getDams } from 'scripts/api';
 
 const damsActions = createActions({
   load: {},

--- a/app/scripts/actions/waterpoints.es6
+++ b/app/scripts/actions/waterpoints.es6
@@ -1,5 +1,5 @@
 import { createActions } from 'reflux';
-import { getWaterpoints } from '../api';
+import { getWaterpoints } from 'scripts/api';
 
 const waterpointActions = createActions({
   load: {},

--- a/app/scripts/api.es6
+++ b/app/scripts/api.es6
@@ -1,4 +1,4 @@
-import ckan from './utils/ckan';
+import ckan from 'utils/ckan';
 
 
 const API_ROOT = '//data.takwimu.org/api';
@@ -14,4 +14,3 @@ export const getBoreholes = () =>
 
 export const getDams = () =>
   ckan.get(resourceUrl('d6dcc9f8-c480-4bd0-b748-2d0b12d92396'));
-

--- a/app/scripts/app.jsx
+++ b/app/scripts/app.jsx
@@ -2,14 +2,14 @@
 import React from 'react';
 import Router, {Route, IndexRoute} from 'react-router';
 
-import Root from './components/root.jsx';
-import WaterPoints from './components/dashboard/waterpoints.jsx';
-import WaterPoint from './components/dashboard/waterpoint.jsx';
-import Polygons from './components/dashboard/polygons.jsx';
-import Polygon from './components/dashboard/polygon.jsx';
-import Data from './components/static/data.jsx';
-import SpeakOut from './components/static/speak-out.jsx';
-import NotFound from './components/static/not-found.jsx';
+import Root from 'components/root.jsx';
+import WaterPoints from 'components/dashboard/waterpoints.jsx';
+import WaterPoint from 'components/dashboard/waterpoint.jsx';
+import Polygons from 'components/dashboard/polygons.jsx';
+import Polygon from 'components/dashboard/polygon.jsx';
+import Data from 'components/static/data.jsx';
+import SpeakOut from 'components/static/speak-out.jsx';
+import NotFound from 'components/static/not-found.jsx';
 
 
 React.render((

--- a/app/scripts/components/boilerplate/footer.jsx
+++ b/app/scripts/components/boilerplate/footer.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import T from '../utils/t';
+import T from 'components/utils/t';
 import OpenDataNav from './open-data-nav';
 
 require('stylesheets/boilerplate/footer');

--- a/app/scripts/components/boilerplate/header.jsx
+++ b/app/scripts/components/boilerplate/header.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import T from '../utils/t';
+import T from 'components/utils/t';
 import OpenDataNav from './open-data-nav';
 import LanguageSelector from './language-selector';
 

--- a/app/scripts/components/boilerplate/language-selector.jsx
+++ b/app/scripts/components/boilerplate/language-selector.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import T from '../utils/t';
+import T from 'components/utils/t';
 
 require('stylesheets/boilerplate/language-selector');
 

--- a/app/scripts/components/boilerplate/open-data-nav.jsx
+++ b/app/scripts/components/boilerplate/open-data-nav.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import {Link} from 'react-router';
-import T from '../utils/t';
+import T from 'components/utils/t';
 
 require('stylesheets/boilerplate/open-data-nav');
 

--- a/app/scripts/components/boilerplate/view-mode.jsx
+++ b/app/scripts/components/boilerplate/view-mode.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import {Link} from 'react-router';
-import T from '../utils/t';
+import T from 'components/utils/t';
 
 require('stylesheets/boilerplate/view-mode');
 

--- a/app/scripts/components/dashboard/charts-container.jsx
+++ b/app/scripts/components/dashboard/charts-container.jsx
@@ -1,6 +1,6 @@
 import React, { PropTypes } from 'react';
-import T from '../utils/t';
-import ViewMode from '../boilerplate/view-mode';
+import T from 'components/utils/t';
+import ViewMode from 'components/boilerplate/view-mode';
 
 require('stylesheets/dashboard/charts-container');
 

--- a/app/scripts/components/dashboard/filters.jsx
+++ b/app/scripts/components/dashboard/filters.jsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { connect } from 'reflux';
-import { setSomeFilter } from '../../actions/filters';
-import FilterStore from '../../stores/filters';
-import T from '../utils/t';
+import { setSomeFilter } from 'actions/filters';
+import FilterStore from 'stores/filters';
+import T from 'components/utils/t';
 
 require('stylesheets/dashboard/filters');
 

--- a/app/scripts/components/dashboard/polygons.jsx
+++ b/app/scripts/components/dashboard/polygons.jsx
@@ -1,6 +1,6 @@
 import React, { PropTypes } from 'react';
 import {Link} from 'react-router';
-import T from '../utils/t';
+import T from 'components/utils/t';
 import ChartsContainer from './charts-container';
 
 

--- a/app/scripts/components/dashboard/waterpoint.jsx
+++ b/app/scripts/components/dashboard/waterpoint.jsx
@@ -1,5 +1,5 @@
 import React,  { PropTypes } from 'react';
-import T from '../utils/t';
+import T from 'components/utils/t';
 import WaterPoints from './waterpoints';
 
 const WaterPoint = React.createClass({

--- a/app/scripts/components/dashboard/waterpoints.jsx
+++ b/app/scripts/components/dashboard/waterpoints.jsx
@@ -1,10 +1,10 @@
 import React, { PropTypes } from 'react';
 import { connect } from 'reflux';
-import { load } from '../../actions/waterpoints';
-import WaterPointsStore from '../../stores/waterpoints';
+import { load } from 'actions/waterpoints';
+import WaterPointsStore from 'stores/waterpoints';
 import { TileLayer } from 'react-leaflet';
-import BoundsMap from '../leaflet/bounds-map';
-import WaterpointMarker from '../leaflet/waterpoint-marker';
+import BoundsMap from 'components/leaflet/bounds-map';
+import WaterpointMarker from 'components/leaflet/waterpoint-marker';
 import ChartsContainer from './charts-container';
 
 require('stylesheets/dashboard/waterpoints');

--- a/app/scripts/components/utils/t.jsx
+++ b/app/scripts/components/utils/t.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import warn from '../../utils/warn';
+import warn from 'utils/warn';
 
 
 const stringsEn = {

--- a/app/scripts/stores/boreholes.es6
+++ b/app/scripts/stores/boreholes.es6
@@ -1,6 +1,6 @@
 import { createStore } from 'reflux';
-import SaneStore from '../utils/sane-store-mixin';
-import { loadCompleted } from '../actions/boreholes';
+import SaneStore from 'utils/sane-store-mixin';
+import { loadCompleted } from 'actions/boreholes';
 
 
 const BoreholesStore = createStore({

--- a/app/scripts/stores/dams.es6
+++ b/app/scripts/stores/dams.es6
@@ -1,6 +1,6 @@
 import { createStore } from 'reflux';
-import SaneStore from '../utils/sane-store-mixin';
-import { loadCompleted } from '../actions/dams';
+import SaneStore from 'utils/sane-store-mixin';
+import { loadCompleted } from 'actions/dams';
 
 
 const DamsStore = createStore({

--- a/app/scripts/stores/filters.es6
+++ b/app/scripts/stores/filters.es6
@@ -1,7 +1,7 @@
 import assign from 'object-assign';
 import { createStore } from 'reflux';
-import SaneStore from '../utils/sane-store-mixin';
-import { setSomeFilter } from '../actions/filters';
+import SaneStore from 'utils/sane-store-mixin';
+import { setSomeFilter } from 'actions/filters';
 
 
 const FilterStore = createStore({

--- a/app/scripts/stores/waterpoints.es6
+++ b/app/scripts/stores/waterpoints.es6
@@ -1,6 +1,6 @@
 import { createStore } from 'reflux';
-import SaneStore from '../utils/sane-store-mixin';
-import { loadCompleted } from '../actions/waterpoints';
+import SaneStore from 'utils/sane-store-mixin';
+import { loadCompleted } from 'actions/waterpoints';
 
 
 const WaterPointsStore = createStore({

--- a/webpack.dev.config.js
+++ b/webpack.dev.config.js
@@ -6,16 +6,16 @@ module.exports = {
   entry: [
     'webpack-dev-server/client?http://localhost:3000',
     'webpack/hot/only-dev-server',
-    './app/scripts/app.jsx'
+    './app/scripts/app.jsx',
   ],
   output: {
     path: __dirname,
-    filename: "bundle.js"
+    filename: 'bundle.js',
   },
   devtool: '#cheap-module-eval-source-map',
   plugins: [
     new webpack.HotModuleReplacementPlugin(),
-    new ExtractTextPlugin('style.css')
+    new ExtractTextPlugin('style.css'),
   ],
   module: {
     loaders: [
@@ -24,9 +24,9 @@ module.exports = {
         loaders: ['react-hot', 'babel'],
         include: [
           path.join(__dirname, 'app', 'scripts'),
-          path.join(__dirname, 'node_modules', 'react-leaflet')
+          path.join(__dirname, 'node_modules', 'react-leaflet'),
         ],
-        exclude: /node_modules\/(?!react-leaflet)/
+        exclude: /node_modules\/(?!react-leaflet)/,
       },
       {
         test: /\.scss$/,
@@ -36,14 +36,14 @@ module.exports = {
           'sass?sourceMap'
         ),
         include: path.join(__dirname, 'app', 'stylesheets'),
-      }
-    ]
+      },
+    ],
   },
   resolve: {
     alias: {
       stylesheets: path.resolve(__dirname, 'app', 'stylesheets'),
-      'react-leaflet': path.resolve(__dirname, 'node_modules', 'react-leaflet', 'src')
+      'react-leaflet': path.resolve(__dirname, 'node_modules', 'react-leaflet', 'src'),
     },
-    extensions: ["", ".es6", ".js", ".jsx", ".scss"]
-  }
+    extensions: ['', '.es6', '.js', '.jsx', '.scss'],
+  },
 };

--- a/webpack.dev.config.js
+++ b/webpack.dev.config.js
@@ -41,8 +41,13 @@ module.exports = {
   },
   resolve: {
     alias: {
+      actions: path.resolve(__dirname, 'app', 'scripts', 'actions'),
+      components: path.resolve(__dirname, 'app', 'scripts', 'components'),
+      scripts: path.resolve(__dirname, 'app', 'scripts'),
+      stores: path.resolve(__dirname, 'app', 'scripts', 'stores'),
       stylesheets: path.resolve(__dirname, 'app', 'stylesheets'),
       'react-leaflet': path.resolve(__dirname, 'node_modules', 'react-leaflet', 'src'),
+      utils: path.resolve(__dirname, 'app', 'scripts', 'utils'),
     },
     extensions: ['', '.es6', '.js', '.jsx', '.scss'],
   },


### PR DESCRIPTION
Makes module import paths clearer, and hopefully makes refactoring easier.

Does not seem to work for styles. oh well.
