### PR TITLE
Make warn log with console.error instead of console.warn

### DIFF
--- a/app/scripts/utils/warn.es6
+++ b/app/scripts/utils/warn.es6
@@ -3,5 +3,5 @@
  * Wrap console warnings in a test-safe mockable function
  * @returns {undefined}
  */
-const warn = (...args) => console.warn(...args);
+const warn = (...args) => console.error(...args);
 export default warn;


### PR DESCRIPTION
console.error gives us stack traces, hopefully making debugging the warnings easier.
