### PR TITLE
Install react-leaflet from npm instead of github

### DIFF
--- a/app/scripts/components/leaflet/bounds-map.jsx
+++ b/app/scripts/components/leaflet/bounds-map.jsx
@@ -1,8 +1,8 @@
 /* eslint react/no-set-state: 0 */  // needed for wrapping leaflet
 import assign from 'object-assign';
 import Leaflet from 'leaflet';
-import boundsType from 'react-leaflet/types/bounds';
-import LeafletMap from 'react-leaflet/Map';
+import boundsType from 'react-leaflet/lib/types/bounds';
+import LeafletMap from 'react-leaflet/lib/Map';
 
 const boundsPropTypes = assign({}, LeafletMap.propTypes);
 boundsPropTypes.bounds = boundsType;

--- a/app/scripts/components/leaflet/waterpoint-marker.jsx
+++ b/app/scripts/components/leaflet/waterpoint-marker.jsx
@@ -1,7 +1,7 @@
 import pick from 'lodash/object/pick';
 import React, { PropTypes } from 'react';
 import { Popup } from 'react-leaflet';
-import PopupContainer from 'react-leaflet/PopupContainer';
+import PopupContainer from 'react-leaflet/lib/PopupContainer';
 import { Map, Icon, marker } from 'leaflet';
 
 export default class WaterpointMarker extends PopupContainer {

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "object-assign": "4.0.1",
     "react": "0.13.3",
     "react-font-awesome": "https://github.com/janmyler/react-font-awesome/tarball/261c1719581e9125a544f8b5b9efc2e27073d970",
-    "react-leaflet": "https://github.com/PaulLeCam/react-leaflet/archive/v0.7.0.tar.gz",
+    "react-leaflet": "0.7.0",
     "react-router": "1.0.0-rc1",
     "reflux": "0.2.12",
     "results": "0.5.1",

--- a/webpack.dev.config.js
+++ b/webpack.dev.config.js
@@ -42,7 +42,6 @@ module.exports = {
   resolve: {
     alias: {
       stylesheets: path.resolve(__dirname, 'app', 'stylesheets'),
-      'react-leaflet': path.resolve(__dirname, 'node_modules', 'react-leaflet', 'src')
     },
     extensions: ["", ".es6", ".js", ".jsx", ".scss"]
   }


### PR DESCRIPTION
use the babel-transformed sources distributed in lib/

later we can change to src/ when the next stable version of react-leaflet comes out
