### PR TITLE
change t-child-prop component to work with charts

### DIFF
--- a/app/scripts/components/dashboard/charts/boreholes-chart.jsx
+++ b/app/scripts/components/dashboard/charts/boreholes-chart.jsx
@@ -5,7 +5,7 @@ import TSetChildProps from '../../misc/t-set-child-props';
 
 require('stylesheets/dashboard/charts/boreholes-chart');
 
-const StackBarChart = React.createClass({
+const BoreholesChart = React.createClass({
   propTypes: {
     boreholes: PropTypes.array.isRequired,
   },
@@ -37,13 +37,12 @@ const StackBarChart = React.createClass({
               data={this.parseData(dataRes)}
               height={200}
               margin={{top: 10, bottom: 50, left: 50, right: 10}}
-              title={{k: 'chart.boreholes.title' }}
               width={500}
-              xAxisLabel={{k: 'chart.boreholes.x-axis' }}
-              yAxisLabel={{k: 'chart.boreholes.y-axis' }} />
+              xAxis={{label: {k: 'chart.boreholes.x-axis' }}}
+              yAxis={{label: {k: 'chart.boreholes.y-axis' }}} />
         </TSetChildProps>
       </div>);
   },
 });
 
-export default StackBarChart;
+export default BoreholesChart;

--- a/app/scripts/components/dashboard/charts/boreholes-stats-chart.jsx
+++ b/app/scripts/components/dashboard/charts/boreholes-stats-chart.jsx
@@ -73,8 +73,9 @@ const BoreholesStatsChart = React.createClass({
               data={this.parseData(dataRes)}
               height={200}
               margin={{top: 10, bottom: 50, left: 50, right: 10}}
-              title={{k: 'chart.boreholes.title' }}
-              width={800} />
+              width={800}
+              xAxis={{innerTickSize: 6, label: {k: 'chart.boreholes-stats.x-axis'}}}
+              yAxis={{innerTickSize: 6, label: {k: 'chart.boreholes-stats.y-axis'}}} />
         </TSetChildProps>
         <lu className="boreholes-options">
           {Object.keys(this.state).map(metric =>

--- a/app/scripts/components/dashboard/charts/waterpoint-functional-chart.jsx
+++ b/app/scripts/components/dashboard/charts/waterpoint-functional-chart.jsx
@@ -32,10 +32,9 @@ const WaterpointFunctionalChart = React.createClass({
               data={this.parseData(waterpointsRes)}
               height={200}
               margin={{top: 10, bottom: 50, left: 50, right: 10}}
-              title={{k: 'chart.functional-waterpoints.title'}}
               width={500}
-              xAxisLabel={{k: 'chart.functional-waterpoints.x-axis'}}
-              yAxisLabel={{k: 'chart.functional-waterpoints.y-axis'}} />
+              xAxis={{label: {k: 'chart.functional-waterpoints.x-axis'}}}
+              yAxis={{label: {k: 'chart.functional-waterpoints.y-axis'}}} />
         </TSetChildProps>
       </div>);
   },

--- a/app/scripts/components/dashboard/charts/waterpoint-status-chart.jsx
+++ b/app/scripts/components/dashboard/charts/waterpoint-status-chart.jsx
@@ -49,12 +49,10 @@ const WaterpointStatusChart = React.createClass({
           <BarChart
               data={this.parseData(dataRes)}
               height={200}
-              legend={true}
               margin={{top: 10, bottom: 50, left: 50, right: 10}}
-              title={{k: 'chart.status-waterpoints.title'}}
               width={500}
               xAxis={{innerTickSize: 6, label: {k: 'chart.status-waterpoints.x-axis'}}}
-              yAxisLabel={{k: 'chart.status-waterpoints.y-axis'}} />
+              yAxis={{innerTickSize: 6, label: {k: 'chart.status-waterpoints.y-axis'}}} />
           </TSetChildProps>
       </div>);
   },

--- a/app/scripts/components/misc/__tests__/t-set-child-props-test.jsx
+++ b/app/scripts/components/misc/__tests__/t-set-child-props-test.jsx
@@ -20,6 +20,26 @@ describe('Translator component wrapper', () => {
     expect(attrText).toEqual('Water Dashboard');
   });
 
+  it('should put translated props on the object prop which has a k', () => {
+    const ts = React.addons.TestUtils.renderIntoDocument(
+      <TS>
+        <text tooltip={{propA: {k: 'site-name'}}} />
+      </TS>
+    );
+    const wc = React.addons.TestUtils.findRenderedDOMComponentWithTag(ts, 'text');
+    const objTranslated = wc.props.tooltip;
+    expect(objTranslated).toBeDefined();
+    expect(objTranslated).toEqual({propA: 'Water Dashboard'});
+  });
+
+  it('should break to put translated props on the object prop which has two a k', () => {
+    expect(() => React.addons.TestUtils.renderIntoDocument(
+      <TS>
+        <text tooltip={{propA: {k: 'site-name'}, propB: {k: 'site.flag'}}} />
+      </TS>
+    )).toThrow('TSetChildProps on object props should one k element.');
+  });
+
   it('should break for no children', () => {
     expect(() => React.addons.TestUtils.renderIntoDocument(
       <TS />

--- a/app/scripts/components/misc/t-set-child-props.jsx
+++ b/app/scripts/components/misc/t-set-child-props.jsx
@@ -7,6 +7,25 @@ import { connect } from 'reflux';
 import langStore from '../../stores/lang';
 import { translate } from './t';
 
+
+/**
+ * This component can be used inject translations into the props of its children
+ *
+ * Use it to wrap a single component which has props that you want to translate,
+ * setting those props to a `{k: 'translation.k', i: ['interpolations']}`
+ * object (the `i` key is optional).
+ *
+ * It will also check one-level deep for a single nested tranlation object, and
+ * throw if there is more than one.
+ *
+ * Examples:
+ *
+ *     <TSetChildProps><img alt={k: 'site-name'} /></TSetChildProps>
+ *
+ *     <TSetChildProps>
+ *       <Chart xAxis={label: {k: 'chart.x-axis-label'}} />
+ *     </TSetChildProps>
+ */
 const TSetChildProps = React.createClass({
   propTypes: {
     children: React.PropTypes.node.isRequired,

--- a/app/scripts/components/misc/t-set-child-props.jsx
+++ b/app/scripts/components/misc/t-set-child-props.jsx
@@ -39,6 +39,9 @@ const TSetChildProps = React.createClass({
   getKObject(obj) {
     return Object.keys(obj).reduce((ret, propName) => {
       if (isObject(obj[propName]) && !isUndefined(obj[propName].k) && isString(obj[propName].k)) {
+        if (ret.found) {
+          throw new Error('TSetChildProps on object props should one k element.');
+        }
         ret.found = true;
         ret.kOjb = obj[propName];
         ret.propName = propName;

--- a/app/scripts/components/misc/t-set-child-props.jsx
+++ b/app/scripts/components/misc/t-set-child-props.jsx
@@ -36,10 +36,25 @@ const TSetChildProps = React.createClass({
     }
   },
 
+  getKObject(obj) {
+    return Object.keys(obj).reduce((ret, propName) => {
+      if (isObject(obj[propName]) && !isUndefined(obj[propName].k) && isString(obj[propName].k)) {
+        ret.found = true;
+        ret.kOjb = obj[propName];
+        ret.propName = propName;
+      }
+      return ret;
+    }, {found: false});
+  },
+
   isTranslateObj(obj) {
-    if (!isObject(obj) || isUndefined(obj.k)) {
+    if (!isObject(obj)) {
       return false;
-    } else if (!isString(obj.k)) {  // k but wrong type -- probably a mistake
+    } else if (this.getKObject(obj).found) {
+      return true;
+    } else if (isUndefined(obj.k)) {
+      return false;
+    } else if (!isString(obj.k)) { // k but wrong type -- probably a mistake
       warn('Tried to translate obj', obj, 'but `k` was not a string.');
       return false;
     } else {
@@ -48,7 +63,15 @@ const TSetChildProps = React.createClass({
   },
 
   translateObj(obj) {
-    return translate(this.state.lang, obj.k, obj.i);
+    const nestedKOjject = this.getKObject(obj);
+    if (nestedKOjject.found) {
+      return {
+        ...obj,
+        [nestedKOjject.propName]: translate(this.state.lang, nestedKOjject.kOjb.k, nestedKOjject.kOjb.i),
+      };
+    } else {
+      return translate(this.state.lang, obj.k, obj.i);
+    }
   },
 
   getTranslatedProps(child) {

--- a/app/scripts/components/misc/t.jsx
+++ b/app/scripts/components/misc/t.jsx
@@ -51,6 +51,9 @@ const allTranslations = {
     'chart.boreholes.DYNAMIC_WATER_LEVEL_METER': 'Dynamic Water Level',
     'chart.boreholes.DRAW _DOWN_METER': 'Draw Down Meter',
     'chart.boreholes.YIELD_METER_CUBED_PER_HOUR': 'Yield meter cubed per Hour',
+    'chart.boreholes-stats.x-axis': 'Years',
+    'chart.boreholes-stats.y-axis': '#',
+
 
     'view-mode.points': 'All Water Points',
     'view-mode.region': 'Region',


### PR DESCRIPTION
The react-d3-component library uses an object for the axis props, such as:
`xAxis={{label: {k: 'chart.boreholes.x-axis' }}}`

therefore the TSetChildProps won't work, so I look into 1 level to look for the k attribute.
more info about react-d3-component axis: https://github.com/codesuki/react-d3-components#axis-parameters
